### PR TITLE
fix: nginx race condition

### DIFF
--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -59,7 +59,7 @@ services:
     environment:
       CSRF_COOKIE_DOMAIN: .aether.local
       DJANGO_SECRET_KEY: ${KERNEL_DJANGO_SECRET_KEY}
-
+      DJANGO_STORAGE_BACKEND: filesystem
       ADMIN_USERNAME: ${KERNEL_ADMIN_USERNAME}
       ADMIN_PASSWORD: ${KERNEL_ADMIN_PASSWORD}
       ADMIN_TOKEN: ${KERNEL_ADMIN_TOKEN}
@@ -99,6 +99,7 @@ services:
     environment:
       CSRF_COOKIE_DOMAIN: .aether.local
       DJANGO_SECRET_KEY: ${ODK_DJANGO_SECRET_KEY}
+      DJANGO_STORAGE_BACKEND: filesystem
 
       ADMIN_USERNAME: ${ODK_ADMIN_USERNAME}
       ADMIN_PASSWORD: ${ODK_ADMIN_PASSWORD}
@@ -139,6 +140,7 @@ services:
     environment:
       CSRF_COOKIE_DOMAIN: .aether.local
       DJANGO_SECRET_KEY: ${UI_DJANGO_SECRET_KEY}
+      DJANGO_STORAGE_BACKEND: filesystem
 
       ADMIN_USERNAME: ${UI_ADMIN_USERNAME}
       ADMIN_PASSWORD: ${UI_ADMIN_PASSWORD}

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -55,7 +55,7 @@ services:
   # ---------------------------------
 
   kernel-base:
-    image: ehealthafrica/aether-kernel:${AETHER_VERSION:-latest}
+    image: ehealthafrica/aether-kernel:${AETHER_VERSION}
     environment:
       CSRF_COOKIE_DOMAIN: .aether.local
       DJANGO_SECRET_KEY: ${KERNEL_DJANGO_SECRET_KEY}
@@ -95,7 +95,7 @@ services:
   # ---------------------------------
 
   odk-base:
-    image: ehealthafrica/aether-odk:${AETHER_VERSION:-latest}
+    image: ehealthafrica/aether-odk:${AETHER_VERSION}
     environment:
       CSRF_COOKIE_DOMAIN: .aether.local
       DJANGO_SECRET_KEY: ${ODK_DJANGO_SECRET_KEY}
@@ -136,7 +136,7 @@ services:
   # ---------------------------------
 
   ui-base:
-    image: ehealthafrica/aether-ui:${AETHER_VERSION:-latest}
+    image: ehealthafrica/aether-ui:${AETHER_VERSION}
     environment:
       CSRF_COOKIE_DOMAIN: .aether.local
       DJANGO_SECRET_KEY: ${UI_DJANGO_SECRET_KEY}
@@ -201,7 +201,7 @@ services:
   # ---------------------------------
 
   aether-producer-base:
-    image: ehealthafrica/aether-producer:${AETHER_VERSION:-latest}
+    image: ehealthafrica/aether-producer:${AETHER_VERSION}
     environment:
       # These variables will override the ones indicated in the settings file
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092


### PR DESCRIPTION
Nginx wasn't starting, not because of the healthchecks, but because containers it depends on ( odk, kernel, ui ) weren't starting. They we missing a required env variable, but this didn't show in the logs if you did compose up. It was only by doing dcp logs after the containers failed that this was obvious. Sneaky.