### PR TITLE
fix: make the links in /forms work in local env

### DIFF
--- a/conf/nginx/sites-enabled/odk.conf
+++ b/conf/nginx/sites-enabled/odk.conf
@@ -38,7 +38,7 @@ server {
     # the ODK module builds links that make sense from outside NGINX.
     proxy_pass              http://odk.aether.local:8002;
 
-    proxy_set_header        Host               $host;
+    proxy_set_header        Host               $host:8443;
     proxy_set_header        X-Real-IP          $remote_addr;
     proxy_set_header        X-Forwarded-For    $proxy_add_x_forwarded_for;
     proxy_set_header        X-Forwarded-Host   $host:8443;


### PR DESCRIPTION
Without the port number in the `Host` header, the /formList endpoint in aether-odk will not include the port number. This means that ODK Collect will receive invalid form URLs and will not be able to download any forms.

(Duplicate of https://github.com/eHealthAfrica/aether/pull/333, but how can we share conf files between the repos? 🤷‍♂️ )