### PR TITLE
chore: give test artifact a real uuid to address pass through non-compliance

### DIFF
--- a/assets/sample-data.json
+++ b/assets/sample-data.json
@@ -1,5 +1,5 @@
 {
-  "_id": "fKPopgxGLyzTUIPelIYLLJhGOYVEa",
+  "_id": "efda2005-7b23-4e1c-857f-b0255fad0991",
   "_version": "YUPRCpknNpjXoRIeFIbTaqcVYBd",
   "start": "2018-07-01 15:32:05",
   "end": "2018-07-01 18:04:47",


### PR DESCRIPTION
Our demo payload contained an invalid UUID which was causing the generated pass-through pipeline to show an error. This addresses that.