### PR TITLE
chore: peg kafka/zookeeper to confluent platform version 5.1.1

### DIFF
--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -181,7 +181,7 @@ services:
   # ---------------------------------
 
   zookeeper-base:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:5.1.1
     environment:
       ZOOKEEPER_CLIENT_PORT: 32181
       ZOOKEEPER_TICK_TIME: 2000
@@ -189,7 +189,7 @@ services:
       - "moby:127.0.0.1"
 
   kafka-base:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:5.1.1
     ports:
       - "29092:29092"
     environment:

--- a/kafka-viewer/start.sh
+++ b/kafka-viewer/start.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2018 by eHealth Africa : http://www.eHealthAfrica.org
+#
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+docker-compose pull
+docker-compose run kafka-viewer start


### PR DESCRIPTION
Using `latest` was opening us up to unexpected breaking changes. We're going to peg to recent version after testing from now on.