### PR TITLE
feat: demo script

### DIFF
--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
+#
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+set -Eeuo pipefail
+
+scripts/initialise_docker_environment.sh
+docker-compose up -d
+docker-compose -f ./docker-compose-connect.yml up -d
+docker-compose -f ./elasticsearch/docker-compose.yml up -d elasticsearch
+gather/setup_gather.sh
+gather/start_gather.sh
+elasticsearch/setup.sh
+elasticsearch/start.sh

--- a/demo/wipe.sh
+++ b/demo/wipe.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
+#
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+set -Eeuo pipefail
+
+docker-compose -f ./docker-compose-connect.yml kill
+docker-compose -f ./docker-compose-connect.yml down
+docker-compose -f ./elasticsearch/docker-compose.yml kill
+docker-compose -f ./elasticsearch/docker-compose.yml down -v
+docker-compose -f ./gather/docker-compose.yml kill
+docker-compose -f ./gather/docker-compose.yml down
+scripts/wipe_kernel.sh
+rm .env

--- a/elasticsearch/docker-compose-base.yml
+++ b/elasticsearch/docker-compose-base.yml
@@ -9,11 +9,6 @@ services:
     environment:
       discovery.type: single-node
       opendistro_security.ssl.http.enabled: "false"
-    volumes:
-      - elasticsearch-data:/usr/share/elasticsearch/data
-      - ./conf/log4j2.properties:/usr/share/elasticsearch/config/log4j2.properties
-      - ./conf/security.yml:/usr/share/elasticsearch/plugins/opendistro_security/securityconfig/config.yml
-      # - ./conf/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
 
   kibana-base:
     image: amazon/opendistro-for-elasticsearch-kibana:0.9.0

--- a/elasticsearch/docker-compose.yml
+++ b/elasticsearch/docker-compose.yml
@@ -9,11 +9,16 @@ volumes:
   elasticsearch-data:
 
 services:
-
+  
   elasticsearch:
     extends:
       file: docker-compose-base.yml
       service: elasticsearch-base
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+      - ./conf/log4j2.properties:/usr/share/elasticsearch/config/log4j2.properties
+      - ./conf/security.yml:/usr/share/elasticsearch/plugins/opendistro_security/securityconfig/config.yml
+      # - ./conf/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
     networks:
       - aether
 


### PR DESCRIPTION
We've made it easier to run a demo with 1.5 by adding `demo/setup.sh` and `demo/wipe.sh`

In `scripts/initialise_docker_environment.sh`

change:
 - `export LOCAL_HOST=aether.local`
_to_
 - `export LOCAL_HOST={your-ip-address}`

then run the following:
```
demo/setup.sh
```

Your credentials are `user:password`

Add your surveys at:
 - `http://{your-ip-address}/dev/gather/`
In ODK Collect, your submission server is:
 - `http://{your-ip-address}:8443/dev/odk`
View your data at:
 - `http://{your-ip-address}/dev/kibana/kibana-app`
