### PR TITLE
chore: demo scripts

### DIFF
--- a/demo/add_tenant.sh
+++ b/demo/add_tenant.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
+#
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+set -Eeuo pipefail
+
+source .env
+source ./scripts/aether_functions.sh
+
+echo_message "Adding tenant $1..."
+echo_message "Starting kong..."
+start_container kong $KONG_INTERNAL
+echo_message "Starting keycloak..."
+start_container keycloak "${KEYCLOAK_INTERNAL}/auth"
+echo_message "Starting other services..."
+demo/up.sh
+echo_message "Waiting for other services..."
+sleep 20
+
+DC_AUTH="docker-compose -f docker-compose-generation.yml"
+AUTH_RUN="$DC_AUTH run --rm auth"
+
+function create_kc_tenant {
+    REALM=$1
+    DESC=${2:-$REALM}
+
+    $AUTH_RUN add_realm \
+        $REALM \
+        "$DESC" \
+        $LOGIN_THEME
+
+    $AUTH_RUN add_public_client \
+        $REALM \
+        $KEYCLOAK_AETHER_CLIENT
+
+    $AUTH_RUN add_oidc_client \
+        $REALM \
+        $KEYCLOAK_KONG_CLIENT
+
+    $AUTH_RUN add_user \
+        $REALM \
+        $KEYCLOAK_INITIAL_USER_USERNAME \
+        $KEYCLOAK_INITIAL_USER_PASSWORD
+
+    $AUTH_RUN add_solution aether $REALM $KEYCLOAK_KONG_CLIENT
+
+    $AUTH_RUN add_kafka_tenant $REALM
+}
+
+function add_es_tenant {
+    REALM=$1
+    echo_message "Adding [kibana] service in kong..."
+    $AUTH_RUN add_service kibana $REALM $KEYCLOAK_KONG_CLIENT
+    $AUTH_RUN add_elasticsearch_tenant $REALM
+}
+
+function add_gather_tenant {
+    REALM=$1
+    echo_message "Adding [gather] solution in kong..."
+    $AUTH_RUN add_solution gather $REALM $KEYCLOAK_KONG_CLIENT
+}
+
+echo_message "Creating initial tenants/realms in keycloak..."
+create_kc_tenant "$1"  "Realm: $1"
+add_es_tenant "$1"
+add_gather_tenant "$1"

--- a/demo/stop.sh
+++ b/demo/stop.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
+#
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+set -Eeuo pipefail
+docker-compose kill
+docker-compose -f ./docker-compose-connect.yml kill
+docker-compose -f ./elasticsearch/docker-compose.yml kill
+docker-compose -f ./gather/docker-compose.yml kill

--- a/demo/up.sh
+++ b/demo/up.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
+#
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+set -Eeuo pipefail
+docker-compose up -d
+docker-compose -f ./docker-compose-connect.yml up -d
+docker-compose -f ./elasticsearch/docker-compose.yml up -d
+docker-compose -f ./gather/docker-compose.yml up -d

--- a/elasticsearch/setup.sh
+++ b/elasticsearch/setup.sh
@@ -25,8 +25,6 @@ source ./.env || \
       exit 1 )
 source ./scripts/aether_functions.sh
 
-DC_AUTH="docker-compose -f docker-compose-generation.yml"
-AUTH_RUN="$DC_AUTH run --rm auth"
 DCES="docker-compose -f ./elasticsearch/docker-compose.yml"
 
 $DCES pull elasticsearch kibana
@@ -38,14 +36,7 @@ start_container keycloak "${KEYCLOAK_INTERNAL}/auth"
 
 $AUTH_RUN setup_elasticsearch
 
-function add_es_tenant {
-    REALM=$1
-    echo_message "Adding [kibana] service in kong..."
-    $AUTH_RUN add_service kibana $REALM $KEYCLOAK_KONG_CLIENT
-    $AUTH_RUN add_elasticsearch_tenant $REALM
-}
-
-
+# From aether_functions.sh
 add_es_tenant "dev"
 add_es_tenant "prod"
 add_es_tenant "test"

--- a/gather/setup_gather.sh
+++ b/gather/setup_gather.sh
@@ -26,8 +26,6 @@ source ./.env || \
       exit 1 )
 source ./scripts/aether_functions.sh
 
-
-AUTH_RUN="docker-compose -f ./docker-compose-generation.yml run --rm auth"
 DCG="docker-compose -f ./gather/docker-compose.yml"
 
 start_container kong     $KONG_INTERNAL
@@ -36,12 +34,7 @@ start_container keycloak "${KEYCLOAK_INTERNAL}/auth"
 $DCG pull gather
 $DCG run --rm --no-deps gather setup
 
-function add_gather_tenant {
-    REALM=$1
-    echo_message "Adding [gather] solution in kong..."
-    $AUTH_RUN add_solution gather $REALM $KEYCLOAK_KONG_CLIENT
-}
-
+# From aether_functions.sh
 add_gather_tenant "dev"
 add_gather_tenant "prod"
 add_gather_tenant "test"

--- a/scripts/initialise_docker_environment.sh
+++ b/scripts/initialise_docker_environment.sh
@@ -34,10 +34,6 @@ source .env
 source ./scripts/aether_functions.sh
 kafka/make_credentials.sh
 
-DC_AUTH="docker-compose -f docker-compose-generation.yml"
-AUTH_RUN="$DC_AUTH run --rm auth"
-
-
 echo_message ""
 echo_message "Initializing Aether environment, this may take 15 minutes depending on bandwidth."
 echo_message ""
@@ -104,33 +100,6 @@ echo_message ""
 
 echo_message "Preparing keycloak..."
 start_container keycloak "${KEYCLOAK_INTERNAL}/auth"
-
-function create_kc_tenant {
-    REALM=$1
-    DESC=${2:-$REALM}
-
-    $AUTH_RUN add_realm \
-        $REALM \
-        "$DESC" \
-        $LOGIN_THEME
-
-    $AUTH_RUN add_public_client \
-        $REALM \
-        $KEYCLOAK_AETHER_CLIENT
-
-    $AUTH_RUN add_oidc_client \
-        $REALM \
-        $KEYCLOAK_KONG_CLIENT
-
-    $AUTH_RUN add_user \
-        $REALM \
-        $KEYCLOAK_INITIAL_USER_USERNAME \
-        $KEYCLOAK_INITIAL_USER_PASSWORD
-
-    $AUTH_RUN add_solution aether $REALM $KEYCLOAK_KONG_CLIENT
-
-    $AUTH_RUN add_kafka_tenant $REALM
-}
 
 echo_message "Creating initial tenants/realms in keycloak..."
 create_kc_tenant "dev"  "Local development"


### PR DESCRIPTION
Added the ability to:
 - Start all demo services | `up.sh`
 - Stop all demo services | `stop.sh`
 - Add an additional tenant | `add_tenant.sh {tenant-name}`