### PR TITLE
fix: do not expose useless ports

### DIFF
--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -24,8 +24,6 @@ services:
       MINIO_ACCESS_KEY: ${MINIO_STORAGE_ACCESS_KEY}
       MINIO_SECRET_KEY: ${MINIO_STORAGE_SECRET_KEY}
     command: minio server --quiet --address minio:9000 /data
-    ports:
-      - 9000:9000
 
   # ---------------------------------
   # Aether kernel
@@ -92,8 +90,6 @@ services:
     volumes:
       # backup folder
       - ./.persistent_data/backups/kernel:/backups
-    ports:
-      - 8000:8000
     command: start
 
 
@@ -154,8 +150,6 @@ services:
     volumes:
       # backup folder
       - ./.persistent_data/backups/odk:/backups
-    ports:
-      - 8002:8002
     command: start
 
 
@@ -205,8 +199,6 @@ services:
     volumes:
       # backup folder
       - ./.persistent_data/backups/ui:/backups
-    ports:
-      - 8004:8004
     command: start
 
 
@@ -225,15 +217,13 @@ services:
         -DrequireClientAuthScheme=digest
         -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
         -Dzookeeper.authProvider.2=org.apache.zookeeper.server.auth.DigestAuthenticationProvider
-    extra_hosts:
-      - moby:127.0.0.1
     volumes:
       - ./kafka/zk_server_jaas.conf:/etc/zookeeper/zk_server_jaas.conf
+    extra_hosts:
+      - moby:127.0.0.1
 
   kafka-base:
     image: confluentinc/cp-kafka:${CONFLUENTINC_VERSION:-5.2.1}
-    ports:
-      - 9092:9092
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:32181
@@ -259,7 +249,6 @@ services:
       KAFKA_LOG4J_LOGGERS: "kafka.authorizer.logger=ERROR"
       KAFKA_LOG4J_ROOT_LOGLEVEL: ERROR
       KAFKA_OPTS: -Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf
-
     volumes:
       - ./kafka/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf
     extra_hosts:
@@ -301,8 +290,6 @@ services:
 
       SERVER_PORT: 5005
       LOG_LEVEL: ERROR
-    ports:
-      - 5005:5005
     command: start
 
 
@@ -351,8 +338,6 @@ services:
 
       KEYCLOAK_LOGLEVEL: ERROR
       ROOT_LOGLEVEL: ERROR
-    ports:
-      - 8080:8080
 
 
   # ---------------------------------

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -51,8 +51,6 @@ services:
       PGPASSWORD: ${TEST_KERNEL_DB_PASSWORD}
 
       WEB_SERVER_PORT: 9000
-    ports:
-      - 9000:9000
     depends_on:
       db-test:
         condition: service_healthy
@@ -83,8 +81,6 @@ services:
       PGPASSWORD: ${TEST_ODK_DB_PASSWORD}
 
       WEB_SERVER_PORT: 9002
-    ports:
-      - 9002:9002
     depends_on:
       db-test:
         condition: service_healthy
@@ -112,8 +108,6 @@ services:
       service: kafka-base
     links:
       - zookeeper-test
-    ports:
-      - 29092:29092
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper-test:32189
@@ -159,8 +153,6 @@ services:
     links:
       - kafka-test
       - zookeeper-test
-    ports:
-      - 9005:9005
     networks:
       - test
 

--- a/gather/docker-compose.yml
+++ b/gather/docker-compose.yml
@@ -55,8 +55,6 @@ services:
       CUSTOM_UWSGI_SERVE_STATIC: "true"
 
       WEB_SERVER_PORT: 8105
-    ports:
-      - 8105:8105
     command: start
     networks:
       - aether

--- a/scripts/generate_env_vars.sh
+++ b/scripts/generate_env_vars.sh
@@ -242,9 +242,9 @@ if [ -e ".env" ]; then
     # check localhost vs base domain
     if [ "$LOCAL_HOST" = "$BASE_DOMAIN" ]; then
         generate_new=no
-        echo "  - Remove it if you want to generate new local credentials."
+        echo "Remove it if you want to generate new local credentials."
     else
-        echo "  - Current domain [$LOCAL_HOST] differs from saved one [$BASE_DOMAIN], generating new credentials"
+        echo "Current domain [$LOCAL_HOST] differs from saved one [$BASE_DOMAIN], generating new credentials"
         mv ".env" ".env.${BASE_DOMAIN}"
     fi
 fi
@@ -259,11 +259,11 @@ cat << EOF
 
 Add to your
 
-    /etc/hosts file (Linux / MacOS)
+    [/etc/hosts] file (Linux / MacOS)
 
 or
 
-    C:\Windows\System32\Drivers\etc\hosts file (Windows)
+    [C:\Windows\System32\Drivers\etc\hosts] file (Windows)
 
 the following line:
 


### PR DESCRIPTION
The only ports needed outside docker network are the kong ones, everything else goes through it or it's hidden.