### PR TITLE
fix: kong auth set up

### DIFF
--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -220,8 +220,6 @@ services:
         -Dzookeeper.authProvider.2=org.apache.zookeeper.server.auth.DigestAuthenticationProvider
     volumes:
       - ./kafka/zk_server_jaas.conf:/etc/zookeeper/zk_server_jaas.conf
-    extra_hosts:
-      - moby:127.0.0.1
 
   kafka-base:
     image: confluentinc/cp-kafka:${CONFLUENTINC_VERSION:-5.2.1}
@@ -252,8 +250,6 @@ services:
       KAFKA_OPTS: -Djava.security.auth.login.config=/etc/kafka/kafka_server_jaas.conf
     volumes:
       - ./kafka/kafka_server_jaas.conf:/etc/kafka/kafka_server_jaas.conf
-    extra_hosts:
-      - moby:127.0.0.1
 
 
   # ---------------------------------
@@ -313,8 +309,8 @@ services:
 
       KONG_PLUGINS: bundled,kong-oidc-auth
     # volumes:
-    # # uncomment to mount logs outside of docker
-    #  - ../.persistent_data/logs/kong:/usr/local/kong/logs/
+    #   # uncomment to mount logs outside of docker
+    #   - ./.persistent_data/logs/kong:/usr/local/kong/logs/
     ports:
       - 80:80
       - 8443:8443  # ODK Collect requirement!!!
@@ -342,6 +338,9 @@ services:
 
       KEYCLOAK_LOGLEVEL: ERROR
       ROOT_LOGLEVEL: ERROR
+    # this is private to the cluster, only open for debugging
+    # ports:
+    #   - 8080:8080
 
 
   # ---------------------------------
@@ -367,8 +366,6 @@ services:
 
       PROJECT_NAME: DefaultDemo
       MAPPING_NAME: default_mapping
-    extra_hosts:
-      - ${BASE_DOMAIN}:${KONG_IP}
 
   auth-base:
     image: ehealthafrica/gateway-manager:${GATEWAY_VERSION:-latest}
@@ -398,5 +395,3 @@ services:
       - ./api-auth/solution:/code/solution
       - ./api-auth/keycloak/realm/realm_template.json:/code/templates/realm_template.json
     command: help
-    extra_hosts:
-      - ${BASE_DOMAIN}:${KONG_IP}

--- a/docker-compose-connect.yml
+++ b/docker-compose-connect.yml
@@ -18,6 +18,9 @@ services:
     restart: on-failure
     networks:
       - aether
+    extra_hosts:
+      - ${BASE_DOMAIN}:${KONG_IP}
+      - moby:127.0.0.1
 
   kafka:
     extends:
@@ -28,6 +31,9 @@ services:
       - zookeeper
     networks:
       - aether
+    extra_hosts:
+      - ${BASE_DOMAIN}:${KONG_IP}
+      - moby:127.0.0.1
 
   # ---------------------------------
   # Aether Kafka Producer

--- a/docker-compose-generation.yml
+++ b/docker-compose-generation.yml
@@ -17,6 +17,8 @@ services:
       service: assets-base
     networks:
       - aether
+    extra_hosts:
+      - ${BASE_DOMAIN}:${KONG_IP}
 
   # ---------------------------------
   # Auth builder Container
@@ -28,3 +30,5 @@ services:
       service: auth-base
     networks:
       - aether
+    extra_hosts:
+      - ${BASE_DOMAIN}:${KONG_IP}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,37 @@ services:
       - aether
 
   # ---------------------------------
+  # API & Auth
+  # ---------------------------------
+
+  kong:
+    extends:
+      file: ./docker-compose-base.yml
+      service: kong-base
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      aether:
+        ipv4_address: ${KONG_IP}
+    extra_hosts:
+      - ${BASE_DOMAIN}:127.0.0.1
+
+  keycloak:
+    extends:
+      file: ./docker-compose-base.yml
+      service: keycloak-base
+    depends_on:
+      db:
+        condition: service_healthy
+      kong:
+        condition: service_started
+    networks:
+      - aether
+    extra_hosts:
+      - ${BASE_DOMAIN}:${KONG_IP}
+
+  # ---------------------------------
   # Aether kernel
   # ---------------------------------
 
@@ -95,37 +126,6 @@ services:
       kong:
         condition: service_started
       keycloak:
-        condition: service_started
-    networks:
-      - aether
-    extra_hosts:
-      - ${BASE_DOMAIN}:${KONG_IP}
-
-  # ---------------------------------
-  # API & Auth
-  # ---------------------------------
-
-  kong:
-    extends:
-      file: ./docker-compose-base.yml
-      service: kong-base
-    depends_on:
-      db:
-        condition: service_healthy
-    networks:
-      aether:
-        ipv4_address: ${KONG_IP}
-    extra_hosts:
-      - ${BASE_DOMAIN}:127.0.0.1
-
-  keycloak:
-    extends:
-      file: ./docker-compose-base.yml
-      service: keycloak-base
-    depends_on:
-      db:
-        condition: service_healthy
-      kong:
         condition: service_started
     networks:
       - aether

--- a/scripts/generate_env_vars.sh
+++ b/scripts/generate_env_vars.sh
@@ -100,6 +100,7 @@ BASE_PROTOCOL=http
 # to be used in the aether containers
 KEYCLOAK_SERVER_URL=http://${LOCAL_HOST}/auth/realms
 
+KEYCLOAK_HOST=http://keycloak:8080
 KEYCLOAK_INTERNAL=http://keycloak:8080/auth
 KONG_INTERNAL=http://kong:8001
 

--- a/scripts/initialise_docker_environment.sh
+++ b/scripts/initialise_docker_environment.sh
@@ -93,7 +93,7 @@ docker-compose run --rm kong kong migrations up
 echo_message ""
 start_container kong $KONG_INTERNAL
 
-$AUTH_RUN setup_auth
+$AUTH_RUN add_app auth $KEYCLOAK_HOST
 echo_message ""
 
 echo_message "Creating Kafka Superuser..."


### PR DESCRIPTION
This PR is a quick workaround to the 404 auth issue. We should implement a better way of setting up the auth service in the `gateway-manager` repo.