### PR TITLE
Feat/rest proxy

### DIFF
--- a/api-auth/service/rest-proxy.json
+++ b/api-auth/service/rest-proxy.json
@@ -1,0 +1,15 @@
+{
+  "name": "rest-proxy",
+  "host": "http://rest-proxy:3333",
+  "oidc_endpoints": [
+    {
+      "name": "protected",
+      "url": "/",
+      "template_path": "/{realm}/rest-proxy",
+      "strip_path": "true",
+      "oidc_override": {
+        "config.user_keys": ["preferred_username", "email", "groups"]
+      }
+    }
+  ]
+}

--- a/rest-proxy/.gitignore
+++ b/rest-proxy/.gitignore
@@ -1,0 +1,1 @@
+./redisdata

--- a/rest-proxy/add_tenant.sh
+++ b/rest-proxy/add_tenant.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
+#
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+set -Eeuo pipefail
+
+source ./.env || \
+    ( echo "Run this script from /aether-bootstrap not from /aether-bootstrap/demo" && \
+      exit 1 )
+source ./scripts/aether_functions.sh
+
+echo_message "You services must be running!"
+echo_message "REST PROXY IS NOT MULTI-TENANT!!!"
+echo_message "ONLY ONE REALM SHOULD BE GRANTED ACCESS"
+echo_message "Adding rest-proxy service tenant $1..."
+
+$AUTH_RUN add_service rest-proxy $1 $KEYCLOAK_KONG_CLIENT

--- a/rest-proxy/docker-compose.yml
+++ b/rest-proxy/docker-compose.yml
@@ -12,9 +12,9 @@ services:
     stdin_open: true
     tty: true
     environment:
-      LOG_LEVEL: DEBUG
+      LOG_LEVEL: ERROR
       PORT: 3333
-      REQUIRES_AUTH: "False"
+      REQUIRES_AUTH: "False"  # Gateway handles this
       REDIS_HOST: rest-proxy-redis
 
     depends_on:

--- a/rest-proxy/docker-compose.yml
+++ b/rest-proxy/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     stdin_open: true
     tty: true
     environment:
-      LOG_LEVEL: ERROR
+      LOG_LEVEL: DEBUG
       PORT: 3333
       REQUIRES_AUTH: "False"
       REDIS_HOST: rest-proxy-redis
@@ -31,6 +31,8 @@ services:
 
   rest-proxy-redis:
     image: redis:3-alpine
-    command: ["--notify-keyspace-events", "KA", "--appendonly", "yes"]
+    command: ["--appendonly", "yes"]
+    volumes:
+      - ./redisdata:/data
     networks:
       - aether

--- a/rest-proxy/docker-compose.yml
+++ b/rest-proxy/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "2.1"
+
+networks:
+  aether:
+    external:
+      name: aether_bootstrap_net
+
+services:
+  rest-proxy:
+    image: ehealthafrica/scheduled-rest-proxy:latest
+    build: .
+    stdin_open: true
+    tty: true
+    environment:
+      LOG_LEVEL: ERROR
+      PORT: 3333
+      REQUIRES_AUTH: "False"
+      REDIS_HOST: rest-proxy-redis
+
+    depends_on:
+      rest-proxy-redis:
+        condition: service_started
+    ports:
+     - 3333:3333
+    command: start
+    networks:
+      - aether
+    extra_hosts:
+      - ${BASE_DOMAIN}:${KONG_IP}
+      - moby:127.0.0.1
+
+  rest-proxy-redis:
+    image: redis:3-alpine
+    command: ["--notify-keyspace-events", "KA", "--appendonly", "yes"]
+    networks:
+      - aether

--- a/rest-proxy/docker-compose.yml
+++ b/rest-proxy/docker-compose.yml
@@ -8,7 +8,6 @@ networks:
 services:
   rest-proxy:
     image: ehealthafrica/scheduled-rest-proxy:latest
-    build: .
     stdin_open: true
     tty: true
     environment:

--- a/rest-proxy/up.sh
+++ b/rest-proxy/up.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
+#
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+set -Eeuo pipefail
+
+source ./.env || \
+    ( echo "Run this script from /aether-bootstrap not from /aether-bootstrap/demo" && \
+      exit 1 )
+docker-compose -f ./rest-proxy/docker-compose.yml up -d


### PR DESCRIPTION
This adds the scheduled rest proxy service as an option for a **single tenant** in an Aether cluster.

To run (after normal cluster setup):
`rest-proxy/add_tenant.sh {tenant}`
`rest-proxy/up.sh`
`visit -> http://aether.local/{realm}/rest-proxy/`
