### PR TITLE
feat: add kafkacat utility to /connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ Session.vim
 *.keystore
 *.truststore
 *_server_jaas.conf
+*kafkacat.conf
 
 # Environment variables
 .env

--- a/connect/docker-compose.yml
+++ b/connect/docker-compose.yml
@@ -101,6 +101,17 @@ services:
     networks:
       - aether
 
+  # ---------------------------------
+  # Kafka Command Line Tool
+  # ---------------------------------
+  kafkacat:
+    image: ehealthafrica/kafkacat:1.4.0
+    environment:
+      - KAFKACAT_CONFIG=/kafkacat.conf
+    volumes:
+      - ./kafkacat.conf:/kafkacat.conf
+    networks:
+      - aether
 
   # ---------------------------------
   # Aether Kafka Producer

--- a/connect/make_credentials.sh
+++ b/connect/make_credentials.sh
@@ -50,8 +50,21 @@ Server {
 EOF
 }
 
+function gen_kafkacat_creds {
+    cat << EOF
+bootstrap.servers=kafka:29092
+sasl.username=$KAFKA_SU_USER
+sasl.password=$KAFKA_SU_PASSWORD
+sasl.mechanism=SCRAM-SHA-512
+security.protocol=sasl_plaintext
+EOF
+}
+
 gen_kafka_creds > connect/kafka_server_jaas.conf
 echo -e "\033[92m[connect/kafka_server_jaas.conf] security file generated!\033[0m"
 
 gen_zookeeper_creds > connect/zk_server_jaas.conf
 echo -e "\033[92m[connect/zk_server_jaas.conf] security file generated!\033[0m"
+
+gen_kafkacat_creds > connect/kafkacat.conf
+echo -e "\033[92m[connect/kafkacat.conf] configuration file generated!\033[0m"

--- a/demo/README.md
+++ b/demo/README.md
@@ -7,7 +7,7 @@ To prepare the environment for the first time execute:
 
 ```bash
 # pulls the containers, creates the needed databases, volumes, the initial tenants...
-scripts/setup.sh
+scripts/init.sh
 ```
 
 To update your installation with new releases and upgrades execute:


### PR DESCRIPTION
Kafkacat allows the user to manually inspect the running kafka instance. This PR generates and mounts credentials into the kafkacat container connected to the docker network to make use easier.

Instructions:
 - Run kafka
 - docker-compose -f /connect/docker-compose.yml run --rm kafkacat
 - kafkacat -L  # shows metadata about the running kafka instance

You can also use it to read or write message directly to the kafka instance.