### PR TITLE
feat: expose elasticsearch @ /{tenant}/elasticsearch

### DIFF
--- a/auth/service/elasticsearch.json
+++ b/auth/service/elasticsearch.json
@@ -1,0 +1,20 @@
+{
+  "name": "elasticsearch",
+  "host": "http://elasticsearch:9200",
+  "oidc_endpoints": [
+    {
+      "name": "protected",
+      "paths": [
+        "/{realm}/{name}"
+      ],
+      "strip_path": "true",
+      "oidc_override": {
+        "config.user_keys": [
+          "preferred_username",
+          "email",
+          "groups"
+        ]
+      }
+    }
+  ]
+}

--- a/elasticsearch/add_tenant.sh
+++ b/elasticsearch/add_tenant.sh
@@ -30,5 +30,6 @@ source scripts/lib.sh || \
       exit 1 )
 source .env
 
-$GWM_RUN add_service kibana       "$1" $KEYCLOAK_KONG_CLIENT
-$GWM_RUN add_elasticsearch_tenant "$1" 7
+$GWM_RUN add_service elasticsearch       "$1" $KEYCLOAK_KONG_CLIENT
+$GWM_RUN add_service kibana              "$1" $KEYCLOAK_KONG_CLIENT
+$GWM_RUN add_elasticsearch_tenant        "$1" 7


### PR DESCRIPTION
This PR allows a user of a realm to directly interact with ES using the ACLs applies to their tenants ES user. We can restrict this route to a Keycloak Role (admin/ es, etc), but for now it's unrestricted.
User of a realm don't have admin rights.
![image](https://user-images.githubusercontent.com/4309669/64526022-836f1000-d302-11e9-9eb3-09eb29cc4ee7.png)
They can see their realm's assets in ES (and crud through the API)
![image](https://user-images.githubusercontent.com/4309669/64526064-9d105780-d302-11e9-80cc-aa215ff90634.png)
But other realm's stuff is off limits:
![image](https://user-images.githubusercontent.com/4309669/64526078-a6012900-d302-11e9-92b2-d41ee51e658a.png)

