### PR TITLE
chore(travis): build only master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ services:
 
 install: true
 
+# build only the master branch
+branches:
+  only:
+    - master
+
 script:
   - ./scripts/travis/tests.sh $TEST_MODE
 


### PR DESCRIPTION
Needs same settings as aether but only for the `master` branch.