### PR TITLE
fix: initial_user -> tenant admin

### DIFF
--- a/auth/add_tenant.sh
+++ b/auth/add_tenant.sh
@@ -50,4 +50,7 @@ $GWM_RUN add_oidc_client \
 $GWM_RUN add_user \
     $REALM \
     $KEYCLOAK_INITIAL_USER_USERNAME \
-    $KEYCLOAK_INITIAL_USER_PASSWORD
+    $KEYCLOAK_INITIAL_USER_PASSWORD \
+    true \
+    $KEYCLOAK_INITIAL_USER_USERNAME@$REALM.aether.org \
+    true


### PR DESCRIPTION
The first user created by the auth/add_tenant script should be the Realm administrator. They're required by the system to change their password on first login.